### PR TITLE
Adjust for ruby 2.4 deprection of Fixnum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.4
+  - 2.4.1
 before_install: gem install bundler -v 1.15.1

--- a/lib/prom_multi_proc/version.rb
+++ b/lib/prom_multi_proc/version.rb
@@ -1,3 +1,3 @@
 module PromMultiProc
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/prom_multi_proc/writer.rb
+++ b/lib/prom_multi_proc/writer.rb
@@ -3,7 +3,7 @@ module PromMultiProc
     attr_reader :socket, :batch_size
 
     def initialize(socket:, batch_size: 1, validate: false)
-      if !batch_size.is_a?(Fixnum) || batch_size <= 0
+      if !batch_size.is_a?(Integer) || batch_size <= 0
         raise PromMultiProcError.new("Invalid batch size: #{batch_size}")
       end
       @batch_size = batch_size


### PR DESCRIPTION
Fixes #1 

Eliminate deprecation warning.

Tested on ruby 2.2, 2.3, and 2.4