### PR TITLE
Raise an error if a metric is missing help.

### DIFF
--- a/lib/prom_multi_proc/base.rb
+++ b/lib/prom_multi_proc/base.rb
@@ -80,6 +80,10 @@ module PromMultiProc
       end
       name = spec["name"].sub(/\A#{prefix}/, "").to_sym
 
+      unless spec["help"] && !spec["help"].strip.empty?
+        raise PromMultiProcError.new("Metric '#{spec['name']}' is missing help")
+      end
+
       labels = (spec["labels"] || []).map(&:to_sym)
       unless labels.all? { |l| valid_metric?(l)  }
         raise PromMultiProcError.new("Invalid label: #{spec.inspect}")


### PR DESCRIPTION
`prom_multi_proc` - or more accurately, the underlying prometheus client library that `prom_multi_proc` uses - requires that metrics have help text (this has been relaxed in newer versions; see https://github.com/prometheus/client_golang/commit/663a9ad019ad4e1a9f121900aa6aa58ac1e0aa7a). If a metric is missing help, we get errors like

```
descriptor Desc{fqName: "app_foo", help: "", constLabels: {}, variableLabels: [bar]} is invalid: empty help string
```

and later when ruby code attempts to use the metric:

```
ERROR (DataProcessor): Handle: metric app_foo does not exist {Name:app_foo LabelValues:[Bar] Method:inc Value:1}
```

This adds a check to make sure that help exists and is non-empty.